### PR TITLE
feat: 도시 통합 검색 기능 구현

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
+import { Search } from "lucide-react";
+import { SearchResults } from "@/components/search/SearchResults";
+
+function SearchContent() {
+  const searchParams = useSearchParams();
+  const query = searchParams.get("q") || "";
+
+  return (
+    <main className="container mx-auto px-4 py-8">
+      <div className="mb-8">
+        <div className="flex items-center gap-3">
+          <Search className="h-8 w-8 text-primary" />
+          <h1 className="text-3xl font-bold">검색 결과</h1>
+        </div>
+      </div>
+      <SearchResults query={query} />
+    </main>
+  );
+}
+
+export default function SearchPage() {
+  return (
+    <Suspense
+      fallback={
+        <main className="container mx-auto px-4 py-8">
+          <div className="flex items-center justify-center py-16">
+            <p className="text-muted-foreground">검색 중...</p>
+          </div>
+        </main>
+      }
+    >
+      <SearchContent />
+    </Suspense>
+  );
+}

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -1,11 +1,28 @@
 "use client";
 
+import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { Search, MapPin, MessageSquare, Users } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { stats } from "@/data/mock-data";
 
 export function HeroSection() {
+  const [searchQuery, setSearchQuery] = useState("");
+  const router = useRouter();
+
+  const handleSearch = () => {
+    if (searchQuery.trim()) {
+      router.push(`/search?q=${encodeURIComponent(searchQuery.trim())}`);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      handleSearch();
+    }
+  };
+
   return (
     <section className="relative overflow-hidden bg-gradient-to-br from-primary/10 via-primary/5 to-background py-16 md:py-24">
       <div className="absolute inset-0 bg-[url('/images/hero-pattern.svg')] opacity-5" />
@@ -26,6 +43,9 @@ export function HeroSection() {
               type="search"
               placeholder="도시, 지역 또는 키워드로 검색..."
               className="h-14 rounded-full border-2 pl-12 pr-4 text-lg shadow-lg focus:border-primary"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              onKeyDown={handleKeyDown}
             />
           </div>
 

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { SearchX } from "lucide-react";
+import { CityCard } from "@/components/home/CityCard";
+import { searchCities } from "@/data/mock-data";
+
+interface SearchResultsProps {
+  query: string;
+}
+
+export function SearchResults({ query }: SearchResultsProps) {
+  const results = searchCities(query);
+
+  if (results.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center">
+        <SearchX className="mb-4 h-16 w-16 text-muted-foreground" />
+        <h2 className="mb-2 text-xl font-semibold">검색 결과가 없습니다</h2>
+        <p className="text-muted-foreground">
+          &quot;{query}&quot;에 대한 검색 결과를 찾을 수 없습니다.
+          <br />
+          다른 키워드로 검색해 보세요.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <p className="mb-6 text-muted-foreground">
+        {query ? (
+          <>
+            &quot;{query}&quot; 검색 결과: <strong>{results.length}</strong>개
+            도시
+          </>
+        ) : (
+          <>
+            전체 도시: <strong>{results.length}</strong>개
+          </>
+        )}
+      </p>
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {results.map((city) => (
+          <CityCard key={city.id} city={city} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/data/mock-data.ts
+++ b/src/data/mock-data.ts
@@ -123,6 +123,110 @@ export const cities: City[] = [
     likes: 45,
     dislikes: 4,
   },
+  {
+    id: 7,
+    name: "인천",
+    region: "수도권",
+    rank: 7,
+    isHot: false,
+    image: "/images/incheon.jpg",
+    budget: "100~200만원",
+    environment: "도심선호",
+    bestSeason: "봄",
+    likes: 52,
+    dislikes: 6,
+  },
+  {
+    id: 8,
+    name: "대구",
+    region: "경상도",
+    rank: 8,
+    isHot: false,
+    image: "/images/daegu.jpg",
+    budget: "100만원 이하",
+    environment: "카페작업",
+    bestSeason: "가을",
+    likes: 61,
+    dislikes: 5,
+  },
+  {
+    id: 9,
+    name: "광주",
+    region: "전라도",
+    rank: 9,
+    isHot: false,
+    image: "/images/gwangju.jpg",
+    budget: "100만원 이하",
+    environment: "카페작업",
+    bestSeason: "봄",
+    likes: 48,
+    dislikes: 3,
+  },
+  {
+    id: 10,
+    name: "속초",
+    region: "강원도",
+    rank: 10,
+    isHot: true,
+    image: "/images/sokcho.jpg",
+    budget: "100~200만원",
+    environment: "자연친화",
+    bestSeason: "여름",
+    likes: 89,
+    dislikes: 7,
+  },
+  {
+    id: 11,
+    name: "여수",
+    region: "전라도",
+    rank: 11,
+    isHot: true,
+    image: "/images/yeosu.jpg",
+    budget: "100~200만원",
+    environment: "자연친화",
+    bestSeason: "여름",
+    likes: 95,
+    dislikes: 6,
+  },
+  {
+    id: 12,
+    name: "경주",
+    region: "경상도",
+    rank: 12,
+    isHot: false,
+    image: "/images/gyeongju.jpg",
+    budget: "100만원 이하",
+    environment: "자연친화",
+    bestSeason: "가을",
+    likes: 73,
+    dislikes: 4,
+  },
+  {
+    id: 13,
+    name: "세종",
+    region: "충청도",
+    rank: 13,
+    isHot: false,
+    image: "/images/sejong.jpg",
+    budget: "100~200만원",
+    environment: "코워킹 필수",
+    bestSeason: "봄",
+    likes: 38,
+    dislikes: 2,
+  },
+  {
+    id: 14,
+    name: "서귀포",
+    region: "제주도",
+    rank: 14,
+    isHot: true,
+    image: "/images/seogwipo.jpg",
+    budget: "200만원 이상",
+    environment: "자연친화",
+    bestSeason: "겨울",
+    likes: 112,
+    dislikes: 9,
+  },
 ];
 
 export const reviews: Review[] = [
@@ -208,4 +312,17 @@ export function getReviewsByCityName(cityName: string): Review[] {
 
 export function getMeetupsByCityName(cityName: string): Meetup[] {
   return meetups.filter((meetup) => meetup.city === cityName);
+}
+
+export function searchCities(query: string): City[] {
+  if (!query.trim()) return cities;
+  const q = query.toLowerCase();
+  return cities.filter(
+    (city) =>
+      city.name.toLowerCase().includes(q) ||
+      city.region.toLowerCase().includes(q) ||
+      city.budget.toLowerCase().includes(q) ||
+      city.environment.toLowerCase().includes(q) ||
+      city.bestSeason.toLowerCase().includes(q)
+  );
 }


### PR DESCRIPTION
## Summary
- 14개 도시 데이터로 확장 (기존 6개 + 신규 8개: 인천, 대구, 광주, 속초, 여수, 경주, 세종, 서귀포)
- `searchCities` 함수 구현 (도시명, 지역, 예산, 환경, 계절 필드 검색)
- `/search?q=검색어` 검색 결과 페이지 생성
- 홈페이지 검색창에서 Enter 입력 시 검색 페이지로 이동

Closes #1

## Test plan
- [ ] `/search?q=제주` → 제주시, 서귀포 표시
- [ ] `/search?q=경상` → 부산, 대구, 경주 표시
- [ ] `/search?q=자연` → 자연친화 환경 도시들 표시
- [ ] `/search?q=여름` → 여름 추천 도시들 표시
- [ ] `/search` (빈 검색어) → 전체 14개 도시 표시
- [ ] 홈에서 검색어 입력 후 Enter → 검색 결과 페이지 이동
- [ ] 검색 결과 없을 때 → "결과 없음" 메시지 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)